### PR TITLE
fix: aligned random pooler input arguments with those of grid pooler

### DIFF
--- a/src/autora/experimentalist/pooler/random_pooler.py
+++ b/src/autora/experimentalist/pooler/random_pooler.py
@@ -1,38 +1,48 @@
 import random
+from typing import Iterable, List, Tuple
 
 import numpy as np
 
 from autora.utils.deprecation import deprecated_alias
+from autora.variable import IV
 
 
-def random_pool(*args, n: int = 1, duplicates: bool = True):
+def random_pool(
+    ivs: List[IV], num_samples: int = 1, duplicates: bool = True
+) -> Iterable:
     """
     Creates combinations from lists of discrete values using random selection.
     Args:
-        *args: m lists of discrete values. One value will be sampled from each list.
+        ivs: List of independent variables
         n: Number of samples to sample
         duplicates: Boolean if duplicate value are allowed.
 
     """
-    l_samples = []
+    l_samples: List[Tuple] = []
     # Create list of pools of values sample from
-    pools = [tuple(pool) for pool in args]
+    l_iv_values = []
+    for iv in ivs:
+        assert iv.allowed_values is not None, (
+            f"gridsearch_pool only supports independent variables with discrete allowed values, "
+            f"but allowed_values is None on {iv=} "
+        )
+        l_iv_values.append(iv.allowed_values)
 
     # Check to ensure infinite search won't occur if duplicates not allowed
     if not duplicates:
-        l_pool_len = [len(set(s)) for s in pools]
+        l_pool_len = [len(set(s)) for s in l_iv_values]
         n_combinations = np.product(l_pool_len)
         try:
-            assert n <= n_combinations
+            assert num_samples <= n_combinations
         except AssertionError:
             raise AssertionError(
-                f"Number to sample n({n}) is larger than the number "
+                f"Number to sample n({num_samples}) is larger than the number "
                 f"of unique combinations({n_combinations})."
             )
 
     # Random sample from the pools until n is met
-    while len(l_samples) < n:
-        l_samples.append(tuple(map(random.choice, pools)))
+    while len(l_samples) < num_samples:
+        l_samples.append(tuple(map(random.choice, l_iv_values)))
         if not duplicates:
             l_samples = [*set(l_samples)]
 

--- a/src/autora/experimentalist/sampler/random_sampler.py
+++ b/src/autora/experimentalist/sampler/random_sampler.py
@@ -4,7 +4,7 @@ from typing import Iterable, Sequence, Union
 from autora.utils.deprecation import deprecated_alias
 
 
-def random_sample(conditions: Union[Iterable, Sequence], n: int = 1):
+def random_sample(conditions: Union[Iterable, Sequence], num_samples: int = 1):
     """
     Uniform random sampling without replacement from a pool of conditions.
     Args:
@@ -18,7 +18,7 @@ def random_sample(conditions: Union[Iterable, Sequence], n: int = 1):
     if isinstance(conditions, Iterable):
         conditions = list(conditions)
     random.shuffle(conditions)
-    samples = conditions[0:n]
+    samples = conditions[0:num_samples]
 
     return samples
 


### PR DESCRIPTION
# Description

The PR fixes #13  and #9. It aligns the input arguments from the random pooler and the grid pooler.

# Type of change

*Delete as appropriate:*
- **fix**: A bug fix

# Features (Optional)
- fixed input arguments
- added test for random pooler
