### PR TITLE
fix: remove error when a delta-field is missing on the state

### DIFF
--- a/src/autora/state/delta.py
+++ b/src/autora/state/delta.py
@@ -140,6 +140,19 @@ def extend(a, b):
     raise NotImplementedError("`extend` not implemented for %s, %s" % (a, b))
 
 
+@extend.register(type(None))
+def extend_none(a, b):
+    """
+    Examples:
+        >>> extend(None, [])
+        []
+
+        >>> extend(None, [3])
+        [3]
+    """
+    return b
+
+
 @extend.register(list)
 def extend_list(a, b):
     """

--- a/src/autora/state/delta.py
+++ b/src/autora/state/delta.py
@@ -95,13 +95,7 @@ class State:
                 appended_value = append(self_value, other_value)
                 updates[self_field_key] = appended_value
             elif delta_behavior == "replace":
-                if (
-                    constructor := self_field.metadata.get("converter", None)
-                ) is not None:
-                    replaced_value = constructor(other_value)
-                else:
-                    replaced_value = other_value
-                updates[self_field_key] = replaced_value
+                updates[self_field_key] = other_value
             else:
                 raise NotImplementedError(
                     "delta_behaviour=`%s` not implemented" % (delta_behavior)

--- a/src/autora/state/delta.py
+++ b/src/autora/state/delta.py
@@ -51,11 +51,9 @@ class State:
         >>> l + Delta(l=list("ghi"), m=list("rst"))
         ListState(l=['a', 'b', 'c', 'g', 'h', 'i'], m=['r', 's', 't'])
 
-        Passing a nonexistent field will cause an error:
+        A non-existent field will be ignored:
         >>> l + Delta(o="not a field")
-        Traceback (most recent call last):
-        ...
-        AttributeError: key=`o` is missing on ListState(l=['a', 'b', 'c'], m=['x', 'y', 'z'])
+        ListState(l=['a', 'b', 'c'], m=['x', 'y', 'z'])
 
         We can also use the `.update` method to do the same thing:
         >>> l.update(l=list("ghi"), m=list("rst"))
@@ -78,21 +76,32 @@ class State:
 
     def __add__(self, other: Delta):
         updates = dict()
-        for key, other_value in other.data.items():
-            try:
-                self_field = next(filter(lambda f: f.name == key, fields(self)))
-            except StopIteration:
-                raise AttributeError("key=`%s` is missing on %s" % (key, self))
+        for self_field in fields(self):
+            self_field_key = self_field.name
+
+            if self_field_key in other.data:
+                other_value = other.data[self_field_key]
+            else:
+                continue
+            assert other_value is not None
+
             delta_behavior = self_field.metadata["delta"]
-            self_value = getattr(self, key)
+            self_value = getattr(self, self_field.name)
+
             if delta_behavior == "extend":
                 extended_value = extend(self_value, other_value)
-                updates[key] = extended_value
+                updates[self_field_key] = extended_value
             elif delta_behavior == "append":
                 appended_value = append(self_value, other_value)
-                updates[key] = appended_value
+                updates[self_field_key] = appended_value
             elif delta_behavior == "replace":
-                updates[key] = other_value
+                if (
+                    constructor := self_field.metadata.get("converter", None)
+                ) is not None:
+                    replaced_value = constructor(other_value)
+                else:
+                    replaced_value = other_value
+                updates[self_field_key] = replaced_value
             else:
                 raise NotImplementedError(
                     "delta_behaviour=`%s` not implemented" % (delta_behavior)


### PR DESCRIPTION
This allows for forward compatibility – if a theorist or experimentalist returns some data we don't understand, perhaps some `delta-metadata` which are only relevant for this delta, and not for the state itself, then just ignore that field.