### PR TITLE
docs: specify empty docstring fields 

### DIFF
--- a/src/autora/experimentalist/pipeline.py
+++ b/src/autora/experimentalist/pipeline.py
@@ -191,7 +191,7 @@ def _merge_dicts(a: dict, b: dict):
         a: the "base" dictionary
         b: the "update" dictionary which takes precendence
 
-    Returns:
+    Returns: the combined dictionary
 
     Originally from https://stackoverflow.com/a/7205107, modified for AER to allow overwriting.
 

--- a/src/autora/state/delta.py
+++ b/src/autora/state/delta.py
@@ -206,8 +206,8 @@ def wrap_to_use_state(f):
     It was inspired by the pytest "fixtures" mechanism.
 
     Args:
-        f: target function to be wrapped such that it can recieve arguments from and
-           contribute Deltas to `State` objects.
+        f: a function with arguments that could be fields on a `State` 
+            and that returns a `Delta`.
 
     Returns: a version of `f` which takes and returns `State` objects.
 

--- a/src/autora/state/delta.py
+++ b/src/autora/state/delta.py
@@ -207,7 +207,7 @@ def wrap_to_use_state(f):
 
     Args:
         f: target function to be wrapped such that it can recieve arguments from and
-        contribute Deltas to `State` objects.
+           contribute Deltas to `State` objects.
 
     Returns: a version of the target function that is compatible with `State` objects.
 

--- a/src/autora/state/delta.py
+++ b/src/autora/state/delta.py
@@ -206,7 +206,7 @@ def wrap_to_use_state(f):
     It was inspired by the pytest "fixtures" mechanism.
 
     Args:
-        f: a function with arguments that could be fields on a `State` 
+        f: a function with arguments that could be fields on a `State`
             and that returns a `Delta`.
 
     Returns: a version of `f` which takes and returns `State` objects.

--- a/src/autora/state/delta.py
+++ b/src/autora/state/delta.py
@@ -206,7 +206,7 @@ def wrap_to_use_state(f):
     It was inspired by the pytest "fixtures" mechanism.
 
     Args:
-        f: target function to be wrapped such that it can recieve arguments from and 
+        f: target function to be wrapped such that it can recieve arguments from and
         contribute Deltas to `State` objects.
 
     Returns: a version of the target function that is compatible with `State` objects.

--- a/src/autora/state/delta.py
+++ b/src/autora/state/delta.py
@@ -206,9 +206,9 @@ def wrap_to_use_state(f):
     It was inspired by the pytest "fixtures" mechanism.
 
     Args:
-        f:
+        f: target function to be wrapped such that it can recieve arguments from and contribute Deltas to `State` objects.
 
-    Returns:
+    Returns: a version of the target function that is compatible with `State` objects.
 
     Examples:
         >>> from autora.state.delta import State, Delta

--- a/src/autora/state/delta.py
+++ b/src/autora/state/delta.py
@@ -209,7 +209,7 @@ def wrap_to_use_state(f):
         f: target function to be wrapped such that it can recieve arguments from and
            contribute Deltas to `State` objects.
 
-    Returns: a version of the target function that is compatible with `State` objects.
+    Returns: a version of `f` which takes and returns `State` objects.
 
     Examples:
         >>> from autora.state.delta import State, Delta

--- a/src/autora/state/delta.py
+++ b/src/autora/state/delta.py
@@ -206,7 +206,8 @@ def wrap_to_use_state(f):
     It was inspired by the pytest "fixtures" mechanism.
 
     Args:
-        f: target function to be wrapped such that it can recieve arguments from and contribute Deltas to `State` objects.
+        f: target function to be wrapped such that it can recieve arguments from and 
+        contribute Deltas to `State` objects.
 
     Returns: a version of the target function that is compatible with `State` objects.
 


### PR DESCRIPTION
# Description

add descriptions to empty fields in docstring where appropriate

# Type of change

- **docs**: Documentation only changes