### PR TITLE
refactor!: make dataclass back into standard state

### DIFF
--- a/src/autora/state.py
+++ b/src/autora/state.py
@@ -430,9 +430,6 @@ columns=list("xyz")))).q
         return value, used_key
 
 
-State = StateDict
-
-
 @dataclass(frozen=True)
 class StateDataClass:
     """
@@ -696,6 +693,9 @@ class StateDataClass:
         use `dataclasses.replace` instead.
         """
         return self + Delta(**kwargs)
+
+
+State = StateDataClass
 
 
 def _get_value(f, other: Union[Delta, Mapping]):
@@ -1794,7 +1794,7 @@ class StandardStateDict(StateDict):
             return None
 
 
-StandardState = StandardStateDict
+StandardState = StandardStateDataClass
 
 X = TypeVar("X")
 Y = TypeVar("Y")

--- a/tests/_example_workflow_library.py
+++ b/tests/_example_workflow_library.py
@@ -2,12 +2,12 @@ import pandas as pd
 from sklearn.linear_model import LinearRegression
 
 from autora.experimentalist.grid import grid_pool
-from autora.state import StandardStateDataClass, estimator_on_state, on_state
+from autora.state import StandardState, estimator_on_state, on_state
 from autora.variable import Variable, VariableCollection
 
 
 def initial_state(_):
-    state = StandardStateDataClass(
+    state = StandardState(
         variables=VariableCollection(
             independent_variables=[Variable(name="x", allowed_values=range(100))],
             dependent_variables=[Variable(name="y")],

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -3,7 +3,7 @@ import logging
 import pandas as pd
 from hypothesis import HealthCheck, given, settings
 
-from autora.state import StandardStateDataClass
+from autora.state import StandardState
 
 from .test_serializer import serializer_dump_load_strategy
 from .test_strategies import standard_state_dataclass_strategy
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 @given(standard_state_dataclass_strategy(), serializer_dump_load_strategy)
 @settings(suppress_health_check={HealthCheck.too_slow}, deadline=500)
-def test_state_serialize_deserialize(o: StandardStateDataClass, dump_load):
+def test_state_serialize_deserialize(o: StandardState, dump_load):
     o_loaded = dump_load(o)
     assert o.variables == o_loaded.variables
     assert pd.DataFrame.equals(o.conditions, o_loaded.conditions)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -6,12 +6,12 @@ from hypothesis import HealthCheck, given, settings
 from autora.state import StandardState
 
 from .test_serializer import serializer_dump_load_strategy
-from .test_strategies import standard_state_dataclass_strategy
+from .test_strategies import standard_state_strategy
 
 logger = logging.getLogger(__name__)
 
 
-@given(standard_state_dataclass_strategy(), serializer_dump_load_strategy)
+@given(standard_state_strategy(), serializer_dump_load_strategy)
 @settings(suppress_health_check={HealthCheck.too_slow}, deadline=500)
 def test_state_serialize_deserialize(o: StandardState, dump_load):
     o_loaded = dump_load(o)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -437,7 +437,7 @@ def test_model_strategy_creation(o):
 
 
 @st.composite
-def standard_state_dataclass_strategy(draw):
+def standard_state_strategy(draw):
     variable_collection: VariableCollection = draw(variablecollection_strategy())
     conditions = draw(
         dataframe_strategy(variables=variable_collection.independent_variables)
@@ -462,7 +462,7 @@ def standard_state_dataclass_strategy(draw):
 
 
 @settings(suppress_health_check={HealthCheck.too_slow})
-@given(standard_state_dataclass_strategy())
+@given(standard_state_strategy())
 def test_standard_state_dataclass_strategy_creation(o):
     assert o
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -463,7 +463,7 @@ def standard_state_strategy(draw):
 
 @settings(suppress_health_check={HealthCheck.too_slow})
 @given(standard_state_strategy())
-def test_standard_state_dataclass_strategy_creation(o):
+def test_standard_state_strategy_creation(o):
     assert o
 
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -10,7 +10,7 @@ from hypothesis import strategies as st
 from hypothesis.extra import numpy as st_np
 from hypothesis.extra import pandas as st_pd
 
-from autora.state import StandardStateDataClass
+from autora.state import StandardState
 from autora.variable import ValueType, Variable, VariableCollection
 
 VALUE_TYPE_DTYPE_MAPPING = {
@@ -452,7 +452,7 @@ def standard_state_dataclass_strategy(draw):
         )
     )
     models = draw(st.lists(model_strategy(), min_size=0, max_size=5))
-    s = StandardStateDataClass(
+    s = StandardState(
         variables=variable_collection,
         conditions=conditions,
         experiment_data=experiment_data,

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -1,6 +1,6 @@
 import logging
 
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from .test_serializer import serializer_dump_load_strategy
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
     ),
     serializer_dump_load_strategy,
 )
+@settings(deadline=1000)
 def test_variable_serialize_deserialize(o, dump_load):
     o_loaded = dump_load(o)
     assert o_loaded == o

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -8,7 +8,7 @@ from hypothesis import Verbosity, given, settings
 from hypothesis import strategies as st
 
 from autora.serializer import SupportedSerializer, load_state
-from autora.state import StandardState, State
+from autora.state import StandardState
 from autora.workflow.__main__ import main
 
 _logger = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ _logger = logging.getLogger(__name__)
 example_workflow_library_module = st.sampled_from(["_example_workflow_library"])
 
 
-def validate_model(state: Optional[State]):
+def validate_model(state: Optional[StandardState]):
     assert state is not None
 
     assert state.conditions is not None


### PR DESCRIPTION
# Description

Revert State to be defined as a Dataclass rather than a userdict.

- resolves #57 

# Type of change

- **refactor**: A code change that neither fixes a bug nor adds a feature

If this is a breaking change (which might apply to any of the other kinds of change), note that below, otherwise delete 
this section:
- **BREAKING_CHANGE**: reverses the breaking change from #44 

# Features (Optional)
- Remove StateDict and StandardStateDict
- Rename State from StateDataClass
- Rename StandardState from StandardStateDataClass