### PR TITLE
Add alias for model in standardstate

### DIFF
--- a/src/autora/state.py
+++ b/src/autora/state.py
@@ -1188,6 +1188,100 @@ class StandardState(State):
         metadata={"delta": "extend"},
     )
 
+    @property
+    def iv_names(self) -> List[str]:
+        """
+        Returns the names of the independent variables
+        Examples:
+            >>> s_empty = StandardState()
+            >>> s_empty.iv_names
+            []
+            >>> from autora.variable import VariableCollection, Variable
+            >>> iv_1 = Variable('variable_1')
+            >>> iv_2 = Variable('variable_2')
+            >>> variables = VariableCollection(independent_variables=[iv_1, iv_2])
+            >>> s_variables = StandardState(variables=variables)
+            >>> s_variables.iv_names
+            ['variable_1', 'variable_2']
+        """
+        if not self.variables or not self.variables.independent_variables:
+            return []
+        return [iv.name for iv in self.variables.independent_variables]
+
+    @property
+    def dv_names(self) -> List[str]:
+        """
+        Returns the names of the independent variables
+        Examples:
+            >>> s_empty = StandardState()
+            >>> s_empty.dv_names
+            []
+            >>> from autora.variable import VariableCollection, Variable
+            >>> x = Variable('x')
+            >>> y = Variable('y')
+            >>> variables = VariableCollection(independent_variables=[x], dependent_variables=[y])
+            >>> s_variables = StandardState(variables=variables)
+            >>> s_variables.dv_names
+            ['y']
+        """
+        if not self.variables or not self.variables.dependent_variables:
+            return []
+        return [dv.name for dv in self.variables.dependent_variables]
+
+    @property
+    def X(self) -> pd.DataFrame:
+        """
+        Returns the already observed conditions as a pd.DataFrame
+        Examples:
+            >>> s_empty = StandardState()
+            >>> s_empty.X
+            Empty DataFrame
+            Columns: []
+            Index: []
+            >>> from autora.variable import VariableCollection, Variable
+            >>> x = Variable('x')
+            >>> y = Variable('y')
+            >>> variables = VariableCollection(independent_variables=[x], dependent_variables=[y])
+            >>> experiment_data = pd.DataFrame({'x': [0, 1, 2, 3], 'y': [0, 2, 4, 6]})
+            >>> s = StandardState(variables=variables, experiment_data=experiment_data)
+            >>> s.X
+               x
+            0  0
+            1  1
+            2  2
+            3  3
+        """
+        if self.experiment_data is None:
+            return pd.DataFrame()
+        return self.experiment_data[self.iv_names]
+
+    @property
+    def y(self) -> pd.DataFrame:
+        """
+        Returns the observations as a pd.DataFrame
+        Examples:
+            >>> s_empty = StandardState()
+            >>> s_empty.y
+            Empty DataFrame
+            Columns: []
+            Index: []
+            >>> from autora.variable import VariableCollection, Variable
+            >>> x = Variable('x')
+            >>> y = Variable('y')
+            >>> variables = VariableCollection(independent_variables=[x], dependent_variables=[y])
+            >>> experiment_data = pd.DataFrame({'x': [0, 1, 2, 3], 'y': [0, 2, 4, 6]})
+            >>> s = StandardState(variables=variables, experiment_data=experiment_data)
+            >>> s.y
+               y
+            0  0
+            1  2
+            2  4
+            3  6
+        """
+        if self.experiment_data is None:
+            return pd.DataFrame()
+        return self.experiment_data[self.dv_names]
+
 
 X = TypeVar("X")
 Y = TypeVar("Y")

--- a/src/autora/state.py
+++ b/src/autora/state.py
@@ -1205,15 +1205,29 @@ class StandardState(State):
         >>> (s + dm1 + dm2).models
         [DummyClassifier(constant=1), DummyClassifier(constant=2), DummyClassifier(constant=3)]
 
+        We can use properties X, y, iv_names and dv_names as 'getters' ...
         >>> x_v = Variable('x')
         >>> y_v = Variable('y')
         >>> variables = VariableCollection(independent_variables=[x_v], dependent_variables=[y_v])
         >>> e_data = pd.DataFrame({'x': [1, 2, 3], 'y': [2, 4, 6]})
         >>> s = StandardState(variables=variables, experiment_data=e_data)
         >>> @inputs_from_state
-        ... def add_six(X):
+        ... def show_X(X):
         ...     return X
-        >>> add_six(s)
+        >>> show_X(s)
+           x
+        0  1
+        1  2
+        2  3
+
+        ... but nothing happens if we use them as `setters`:
+        >>> @on_state
+        ... def add_to_X(X):
+        ...     res = X.copy()
+        ...     res['x'] += 1
+        ...     return Delta(X=res)
+        >>> s = add_to_X(s)
+        >>> s.X
            x
         0  1
         1  2


### PR DESCRIPTION
# Description

Reintroduce alias mechanism to get and SET State fields with aliases (here: model for the last model in models)

- resolves #72 

# Type of change
- **feat**: A new feature

# Remarks (Optional)
We should add this feature (also the X, y getter somewhere in the documentation).
Also: We should add a Hint in the tutorials that there are "reserved" autora-names when using the StandardState: variables, conditions, experiment_data, models, iv_names, dv_names, X, y, model

